### PR TITLE
Added this semester links to main page

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Sign up for our listserv by sending a blank email to [join-combee-psg@lists.wisc
 ## Upcoming events!
 **For Fall 2017, Python Study Group will meet every other week on Thursdays at 2 PM in Microbial Sciences Building 5503, starting September 21st**
 
+[Sept. 21, 2017 Meeting](PythonStudyGroup/Fall2017/20170921_Meeting1.md) - Topics Discussion
+
 [Huan Fan](http://fanhuan.github.io/) is a postdoctoral researcher in the Currie Lab in the Department of Bacteriology, and will be leading Python Study Group this semester. 
 
 To recieve updates about the coming semester meetings, sign up for our listserv by sending a blank email to [join-combee-psg@lists.wisc.edu](mailto:join-combee-psg@lists.wisc.edu). 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ To recieve updates about the coming semester meetings, sign up for our listserv 
 
 
 ## Previous Semesters' Meetings
-- [Fall 2017](https://github.com/ComBEE-UW-Madison/PythonStudyGroup/tree/master/Fall2017#python-study-group-fall-2017)
 - [Prior to Summer 2017](https://github.com/ComBEE-UW-Madison/PythonStudyGroup/tree/master/Archive#python-study-group-archive)
 
 


### PR DESCRIPTION
This makes it easier for people to find the page for the current semester and lowers the clicking needed.  It addresses #6.
Though could be altered so that is not yet a link to Fall 2017 Readme in the Previous Semesters' Meetings section.  Couldn't decided if I should do that or not.  
@lizilla1993  let me know what you think.