### PR TITLE
Updates to organization and main page

### DIFF
--- a/2018Spring/README.md
+++ b/2018Spring/README.md
@@ -2,17 +2,18 @@
 
 This sub-directory contains notes and code for Python Study Group Spring 2018. 
 
-20180222
-https://hackmd.io/GYZgLADAjAxgpgEwLQCYYA5hLCAbLpAIwENdikoBOMXMdECOCYOIA===
+[February 8th: Topics Discussion](https://hackmd.io/MYZghgjADALARgMwLQCYAmokwgUxUsFKAViSgDY00Eo4YVgwcg==)
 
-20180308
-https://hackmd.io/UsMPR5W9Q1OKy_k9q5-Khw
+[February 22nd](https://hackmd.io/GYZgLADAjAxgpgEwLQCYYA5hLCAbLpAIwENdikoBOMXMdECOCYOIA===): Pythonic syntax
 
-20180322
-https://hackmd.io/kyofxd_zTTOhYDnZjsywxQ
+[March 8th](https://hackmd.io/UsMPR5W9Q1OKy_k9q5-Khw): Lists, dictionaries, and sets
 
-20180405
-https://hackmd.io/njGuXqcQRAOGyUQfrLxi5A
+[March 22nd](https://hackmd.io/kyofxd_zTTOhYDnZjsywxQ): Pandas and Displaying Data
 
-20180419
-https://hackmd.io/qo2U36yOT22q2ZVUFRwrnw
+[April 5th](https://hackmd.io/njGuXqcQRAOGyUQfrLxi5A): BioPython and working with Sequence Data
+
+[April 19th](https://hackmd.io/qo2U36yOT22q2ZVUFRwrnw): ETE package and working with phylogenetic trees
+
+May 3rd: Cython and speeding up code
+
+

--- a/Archive/Past_Leaders.md
+++ b/Archive/Past_Leaders.md
@@ -3,6 +3,8 @@
 ComBEE is a peer-led group and we are very grateful to the people who volunteered their time and efforts to organizing and leading python study group.
 
 ### Thanks to:
+- Shaurya Chanana - Fall 2018
+- Edward Evans - Spring 2018
 - Huan Fan - Fall 2018
 - Ian Miller - Fall 2015, Fall 2016
 - Tatum Mortimer - Summer 2015

--- a/Archive/README.md
+++ b/Archive/README.md
@@ -5,6 +5,7 @@ This sub-directory contains notes and code for ComBEE Python Study Group prior t
 Special thanks to the [past leaders of python study group](Past_Leaders.md)!
 
 ## Meetings after Summer 2017
+- [Fall 2018](https://github.com/sstevens2/PythonStudyGroup/tree/master/2018Fall#combee-python-study-group-fall-2018) <!--- link may need to be adjusted if this is moved to archive -->
 - [Spring 2018](https://github.com/sstevens2/PythonStudyGroup/tree/master/2018Spring#python-study-group-spring-2018) <!--- link may need to be adjusted if this is moved to archive -->
 - [Fall 2017](https://github.com/sstevens2/PythonStudyGroup/tree/master/Archive/Fall2017#python-study-group-fall-2017)
 

--- a/Archive/README.md
+++ b/Archive/README.md
@@ -5,6 +5,7 @@ This sub-directory contains notes and code for ComBEE Python Study Group prior t
 Special thanks to the [past leaders of python study group](Past_Leaders.md)!
 
 ## Meetings after Summer 2017
+- [Spring 2018](https://github.com/sstevens2/PythonStudyGroup/tree/master/2018Spring#python-study-group-spring-2018) <!--- link may need to be adjusted if this is moved to archive -->
 - [Fall 2017](https://github.com/sstevens2/PythonStudyGroup/tree/master/Archive/Fall2017#python-study-group-fall-2017)
 
 

--- a/Archive/README.md
+++ b/Archive/README.md
@@ -4,6 +4,10 @@ This sub-directory contains notes and code for ComBEE Python Study Group prior t
 
 Special thanks to the [past leaders of python study group](Past_Leaders.md)!
 
+## Meetings after Summer 2017
+- [Fall 2017](https://github.com/sstevens2/PythonStudyGroup/tree/master/Archive/Fall2017#python-study-group-fall-2017)
+
+
 ## Archive of Meetings Prior to Github Org (pre-Summer 2017):
 With google docs where available.
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ This group of researchers meets bi-weekly to discuss coding in python.
 Sign up for our listserv by sending a blank email to [join-combee-psg@lists.wisc.edu](mailto:join-combee-psg@lists.wisc.edu).
 
 ## Upcoming events!
-Python Study Group will meet on alternating Thursdays @ 2 PM in MSB 5503 for the Spring 2019 semester starting date TBA. 
+Python Study Group will resume meeting on alternating Thursdays @ 2 PM in MSB 5503 for the Spring 2019 semester starting date TBA. Check back for updates in Jan 2019 or sign up for our email list to get the latest news!
 
-To recieve updates about the coming semester meetings, sign up for our listserv by sending a blank email to [join-combee-psg@lists.wisc.edu](mailto:join-combee-psg@lists.wisc.edu). 
+To recieve updates about the coming semester meetings, sign up for our email list by sending a blank email to [join-combee-psg@lists.wisc.edu](mailto:join-combee-psg@lists.wisc.edu). 
 
 
 ## Previous Semesters' Meetings
@@ -22,6 +22,6 @@ To recieve updates about the coming semester meetings, sign up for our listserv 
 Special thanks to the [past leaders of python study group](Archive/Past_Leaders.md)!
 
 ### Notes and other info
-- [Prior to Summer 2017](https://github.com/ComBEE-UW-Madison/PythonStudyGroup/tree/master/Archive#python-study-group-archive)
+- [Archive of previous semesters' meetings](https://github.com/ComBEE-UW-Madison/PythonStudyGroup/tree/master/Archive#python-study-group-archive)
 
 

--- a/README.md
+++ b/README.md
@@ -12,21 +12,7 @@ This group of researchers meets bi-weekly to discuss coding in python.
 Sign up for our listserv by sending a blank email to [join-combee-psg@lists.wisc.edu](mailto:join-combee-psg@lists.wisc.edu).
 
 ## Upcoming events!
-Python Study Group will meet on alternating Thursdays @ 2 PM in MSB 5503 for the Spring 2018 semester starting February 8th. 
-
-[February 8th: Topics Discussion](https://hackmd.io/MYZghgjADALARgMwLQCYAmokwgUxUsFKAViSgDY00Eo4YVgwcg==)
-
-February 22nd: Pythonic syntax
-
-March 8th: Lists, dictionaries, and sets
-
-March 22nd: Pandas and Displaying Data
-
-April 5th: BioPython and working with Sequence Data
-
-April 19th: ETE package and working with phylogenetic trees
-
-May 3rd: Cython and speeding up code
+Python Study Group will meet on alternating Thursdays @ 2 PM in MSB 5503 for the Spring 2019 semester starting date TBA. 
 
 To recieve updates about the coming semester meetings, sign up for our listserv by sending a blank email to [join-combee-psg@lists.wisc.edu](mailto:join-combee-psg@lists.wisc.edu). 
 


### PR DESCRIPTION
This PR includes the following (sorry for the lame commit messages)...

- Updates the main page to say watch for Spring 2019
- Moves Spring 2018 info to Spring 2018 Readme
- Updates links to Archive (though may need to update if 2018 folders are moved to archive folder)
- Added 2018 leaders to leaders list

Up to you if you want to move the individual semester folders to the archive at some point but don't forget to update the archive links if you do.